### PR TITLE
Added 'output_dir' Spritesheet Property.

### DIFF
--- a/property_groups.py
+++ b/property_groups.py
@@ -568,6 +568,13 @@ class SpritesheetPropertyGroup(bpy.types.PropertyGroup):
         default = False
     )
 
+    output_dir: bpy.props.StringProperty(
+        name = "Output Directory",
+        description = "The output directory where the spritesheets are to be saved",
+        default = "./Rendered spritesheets",
+        subtype = "DIR_PATH"
+    )
+
     sprite_size: bpy.props.IntVectorProperty(
         name = "Sprite Size",
         description = "How large each individual sprite should be. If non-square, the camera's output will be cropped, not scaled",

--- a/render_operator.py
+++ b/render_operator.py
@@ -1,3 +1,4 @@
+from posixpath import isabs
 import bpy
 import collections
 import json
@@ -221,7 +222,7 @@ class SPRITESHEET_OT_RenderSpritesheetOperator(bpy.types.Operator):
 
         reporting_props.has_any_job_started = True
         reporting_props.job_in_progress = True
-        reporting_props.output_directory = self._base_output_dir()
+        reporting_props.output_directory = self._base_output_dir(context.scene.SpritesheetPropertyGroup)
 
     def cancel(self, context):
         reporting_props = context.scene.ReportingPropertyGroup
@@ -451,13 +452,16 @@ class SPRITESHEET_OT_RenderSpritesheetOperator(bpy.types.Operator):
 
         return
 
-    def _base_output_dir(self) -> str:
+    def _base_output_dir(self, props: SpritesheetPropertyGroup) -> str:
+        if os.path.isabs(props.output_dir):
+            return props.output_dir
+
         if bpy.data.filepath:
             out_dir = os.path.dirname(bpy.data.filepath)
-            return os.path.join(out_dir, "Rendered spritesheets")
+            return os.path.join(out_dir, props.output_dir)
 
         # Use the user's home directory
-        return os.path.join(str(pathlib.Path.home()), "Rendered spritesheets")
+        return os.path.join(str(pathlib.Path.home()), props.output_dir)
 
     def _create_file_path(self, props: SpritesheetPropertyGroup, material_set_index: int, animation_set: Optional[AnimationSetPropertyGroup], rotation_angle: int, include_material_set: bool = True) -> str:
         if bpy.data.filepath:
@@ -465,7 +469,7 @@ class SPRITESHEET_OT_RenderSpritesheetOperator(bpy.types.Operator):
         else:
             filename = "spritesheet"
 
-        output_file_path = os.path.join(self._base_output_dir(), filename)
+        output_file_path = os.path.join(self._base_output_dir(props), filename)
 
         # Make sure output directory exists
         pathlib.Path(os.path.dirname(output_file_path)).mkdir(exist_ok = True)

--- a/ui_panels.py
+++ b/ui_panels.py
@@ -487,6 +487,7 @@ class SPRITESHEET_PT_OutputPropertiesPanel(BaseAddonPanel, bpy.types.Panel):
         self.layout.use_property_split = True
         self.layout.use_property_decorate = False
 
+        self.layout.prop(props, "output_dir")
         self.layout.prop(props, "sprite_size")
 
         col = self.layout.column(heading = "Output Size", align = True)


### PR DESCRIPTION
Added an output directory property. :) If relative, uses the directory of the .blend (as originally did), and if it didn't exist it'll create the directory in your home. If it's an absolute directory it'll use that.